### PR TITLE
fix: error: the item TryFrom is imported redundantly #317

### DIFF
--- a/src/cors.rs
+++ b/src/cors.rs
@@ -13,7 +13,7 @@ use headers::{
     HeaderMapExt, HeaderName, HeaderValue, Origin,
 };
 use http::header;
-use std::{collections::HashSet, convert::TryFrom};
+use std::collections::HashSet;
 
 /// It defines CORS instance.
 #[derive(Clone, Debug)]


### PR DESCRIPTION
This should fix #317 for Rust nightly.

## How Has This Been Tested?
`cargo build --release`